### PR TITLE
Use collation safe comparison for config and attribute value cleanup

### DIFF
--- a/src/FIREGENTO/Magento/Command/Eav/RemoveUnusedMediaCommand.php
+++ b/src/FIREGENTO/Magento/Command/Eav/RemoveUnusedMediaCommand.php
@@ -97,7 +97,7 @@ class RemoveUnusedMediaCommand extends AbstractCommand
                     continue;
                 }
 
-                $value = $coreRead->fetchOne('SELECT value FROM ' . $mediaGallery . ' WHERE value = ?', array($filePath));
+                $value = $coreRead->fetchOne('SELECT value FROM ' . $mediaGallery . ' WHERE BINARY value = ?', array($filePath));
 
                 if ($value == false) {
                     $row = array();

--- a/src/FIREGENTO/Magento/Command/Eav/RestoreUseDefaultValueAttributesCommand.php
+++ b/src/FIREGENTO/Magento/Command/Eav/RestoreUseDefaultValueAttributesCommand.php
@@ -57,7 +57,7 @@ class RestoreUseDefaultValueAttributesCommand extends AbstractCommand
                 foreach ($rows as $row) {
                     // Select the global value if it's the same as the non-global value
                     $results = $db->fetchAll('SELECT * FROM ' . $fullTableName
-                        . ' WHERE entity_type_id = ? AND attribute_id = ? AND store_id = ? AND entity_id = ? AND value = ?',
+                        . ' WHERE entity_type_id = ? AND attribute_id = ? AND store_id = ? AND entity_id = ? AND BINARY value = ?',
                         array($row['entity_type_id'], $row['attribute_id'], 0, $row['entity_id'], $row['value'])
                     );
 

--- a/src/FIREGENTO/Magento/Command/Eav/RestoreUseDefaultValueConfigCommand.php
+++ b/src/FIREGENTO/Magento/Command/Eav/RestoreUseDefaultValueConfigCommand.php
@@ -50,11 +50,11 @@ class RestoreUseDefaultValueConfigCommand extends AbstractCommand
 
             $configData = $db->fetchAll('SELECT DISTINCT path, value FROM ' . $this->_prefixTable('core_config_data') . ' WHERE scope_id = 0');
             foreach($configData as $config) {
-                $count = $db->fetchOne('SELECT COUNT(*) FROM ' . $this->_prefixTable('core_config_data') .' WHERE path = ? AND value = ?', array($config['path'], $config['value']));
+                $count = $db->fetchOne('SELECT COUNT(*) FROM ' . $this->_prefixTable('core_config_data') .' WHERE path = ? AND BINARY value = ?', array($config['path'], $config['value']));
                 if($count > 1) {
                     $output->writeln('Config path ' . $config['path'] . ' with value ' . $config['value']. ' has ' . $count . ' values; deleting non-default values');
                     if(!$isDryRun) {
-                        $db->query('DELETE FROM ' . $this->_prefixTable('core_config_data') . ' WHERE path = ? AND value = ? AND scope_id != ?', array($config['path'], $config['value'], 0));
+                        $db->query('DELETE FROM ' . $this->_prefixTable('core_config_data') . ' WHERE path = ? AND BINARY value = ? AND scope_id != ?', array($config['path'], $config['value'], 0));
                     }
                     $removedConfigValues += ($count-1);
                 }


### PR DESCRIPTION
Depending on the database collation MySQL treats strings as equal which are not equal. For example "Format" and "Formát" are treated as equal and one of them is deleted. By using "BINARY a = b" the comparison is done bytewise. This way only strings which are exactly equal are deleted.