### PR TITLE
Use collation safe comparison for config and attribute value cleanup

### DIFF
--- a/Console/Command/RestoreUseDefaultConfigValueCommand.php
+++ b/Console/Command/RestoreUseDefaultConfigValueCommand.php
@@ -54,11 +54,11 @@ class RestoreUseDefaultConfigValueCommand extends Command
         $db = $resConnection->getConnection();
         $configData = $db->fetchAll('SELECT DISTINCT path, value FROM ' . $db->getTableName('core_config_data') . ' WHERE scope_id = 0');
         foreach ($configData as $config) {
-            $count = $db->fetchOne('SELECT COUNT(*) FROM ' . $db->getTableName('core_config_data') .' WHERE path = ? AND value = ?', array($config['path'], $config['value']));
+            $count = $db->fetchOne('SELECT COUNT(*) FROM ' . $db->getTableName('core_config_data') .' WHERE path = ? AND BINARY value = ?', array($config['path'], $config['value']));
             if ($count > 1) {
                 $output->writeln('Config path ' . $config['path'] . ' with value ' . $config['value']. ' has ' . $count . ' values; deleting non-default values');
                 if (!$isDryRun) {
-                    $db->query('DELETE FROM ' . $db->getTableName('core_config_data') . ' WHERE path = ? AND value = ? AND scope_id != ?', array($config['path'], $config['value'], 0));
+                    $db->query('DELETE FROM ' . $db->getTableName('core_config_data') . ' WHERE path = ? AND BINARY value = ? AND scope_id != ?', array($config['path'], $config['value'], 0));
                 }
                 $removedConfigValues += ($count-1);
             }

--- a/Console/Command/RestoreUseDefaultValueCommand.php
+++ b/Console/Command/RestoreUseDefaultValueCommand.php
@@ -79,7 +79,7 @@ class RestoreUseDefaultValueCommand extends Command
                 // Select the global value if it's the same as the non-global value
                 $results = $db->fetchAll(
                     'SELECT * FROM ' . $fullTableName
-                    . ' WHERE attribute_id = ? AND store_id = ? AND ' . $column . ' = ? AND value = ?',
+                    . ' WHERE attribute_id = ? AND store_id = ? AND ' . $column . ' = ? AND BINARY value = ?',
                     array($row['attribute_id'], 0, $row[$column], $row['value'])
                 );
 


### PR DESCRIPTION
(as requested in #47 my PR for Magento 2)

Depending on the database collation MySQL treats strings as equal which are not equal. For example "Format" and "Formát" are treated as equal and one of them is deleted. By using "BINARY a = b" the comparison is done bytewise. This way only strings which are exactly equal are deleted.